### PR TITLE
Combo Update Here [Archiving Jobs & Sharing on Social]

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,11 +12,13 @@ gem 'coffee-rails', '~> 4.2'
 gem 'turbolinks', '~> 5'
 gem 'jbuilder', '~> 2.5'
 
-gem 'bootsnap', '>= 1.1.0', require: false
+# gem 'bootsnap', '>= 1.1.0', require: false
+gem 'bootsnap', '~> 1.3', require: false
 
 gem 'haml', '~> 5.0', '>= 5.0.4'
 gem 'devise', '~> 4.4', '>= 4.4.3'
 gem 'sendgrid', '~> 1.2', '>= 1.2.4'
+# gem 'twitter', '~> 6.2'
 
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -218,7 +218,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  bootsnap (>= 1.1.0)
+  bootsnap (~> 1.3)
   byebug
   capybara (>= 2.15, < 4.0)
   chromedriver-helper

--- a/app/assets/stylesheets/header.scss
+++ b/app/assets/stylesheets/header.scss
@@ -9,6 +9,7 @@
 
 .page--title {
     color: #EC058C;
+    line-height: 1.2;
     margin: 0;
 }
 
@@ -19,10 +20,45 @@ footer,
     text-align: center;
 }
 
+.page--legend-buttons {
+    margin: 0 0 40px;
+}
+
 .page--legend {
     text-align: center;
-    min-height: 24px;
-    margin: 0 0 40px;
+    line-height: 1.275;
+    min-height: 22px;
+    margin: 0;
+}
+
+.share--buttons {
+    text-align: center;
+    margin-top: 5px;
+}
+
+.share--button {
+    color: #fff;
+    border-radius: 3px;
+    padding: 4px 6px 5px 6px;
+    -webkit-transition: all .25s ease;
+    -moz-transition: all .25s ease;
+    -ms-transition: all .25s ease;
+    -o-transition: all .25s ease;
+    transition: all .25s ease;
+    &:hover {
+        background-color: #333;
+    }
+    &:visited {
+        color: white;
+    }
+}
+
+.share--buttons__tweet {
+    background-color: #1DA1F2;
+}
+
+.share--buttons__fb {
+    background-color: #3B5998;
 }
 
 .main--content {

--- a/app/assets/stylesheets/jobs.scss
+++ b/app/assets/stylesheets/jobs.scss
@@ -13,6 +13,10 @@
     }
 }
 
+.job--list__item-archived {
+    background: #fcffc9;
+}
+
 .job-list__action-group {
     display: flex;
 }
@@ -24,20 +28,35 @@
     }
 }
 
-.job--list__archive-link,
-.job--list__edit-link {
+.job--list__action {
+    font-size: 0.9em;
+    padding: 1px 5px 2px 5px;
     color: #fff;
     border-radius: 3px;
-    background: $dc-blue;
-    padding: 1px 5px 2px 5px;
-    font-size: 0.9em;
-    &:hover {
-        // color: #EC058C;
-        background: $dc-fuschia;
-    }
     &:visited {
         color: #fff;
         text-decoration: none;
+    }
+}
+
+.job--list__action-edit {
+    background: $dc-blue;
+    &:hover {
+        background: #056ceb;
+    }
+}
+
+.job--list__action-archive {
+    background: #eb8f05;
+    &:hover {
+        background: #eb4f05;
+    }
+}
+
+.job--list__action-unarchive {
+    background: #32b32a;
+    &:hover {
+        background: #287323;
     }
 }
 

--- a/app/assets/stylesheets/navbar.scss
+++ b/app/assets/stylesheets/navbar.scss
@@ -19,6 +19,12 @@
     text-decoration: none;
     transition: all 0.5s;
     &:hover {
-        border-bottom: 2px solid #666;
+        border-bottom: 2px solid $dc-blue;
+        ;
+    }
+    &:visited {
+        &:hover {
+            border-bottom: 2px solid #3705ec;
+        }
     }
 }

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,10 @@
 class ApplicationController < ActionController::Base
+
+    # client = Twitter::REST::Client.new do |config|
+    #     config.consumer_key        = ENV['TWITTER_CONSUMER_KEY']
+    #     config.consumer_secret     = ENV['TWITTER_CONSUMER_SECRET']
+    #     config.access_token        = ENV['TWITTER_ACCESS_TOKEN']
+    #     config.access_token_secret = ENV['TWITTER_ACCESS_SECRET']
+    # end
+
 end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,6 +1,6 @@
 class PagesController < ApplicationController
   def index
-    @jobs = Job.all.order('created_at DESC')
+    @jobs = Job.where(:archived => false).order('created_at DESC')    
   end
 
   def help

--- a/app/helpers/jobs_helper.rb
+++ b/app/helpers/jobs_helper.rb
@@ -1,2 +1,11 @@
 module JobsHelper
+
+    def tweetButtonText
+        return "https://twitter.com/intent/tweet?text=" + @job.company + " is looking for a " + @job.role + ". Read more on DevCongress Jobs, " + job_url + (" &hash;devcongressjobs &hash;hiring via @DevCongress").html_safe
+    end
+
+    def fbButtonText
+        return "https://www.facebook.com/sharer.php?u=" + job_url
+    end
+
 end

--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -1,3 +1,11 @@
 class Job < ApplicationRecord
     belongs_to :user
+
+    def is_archived?
+        if self.archived == true
+            return true
+        else
+            return false
+        end        
+    end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,4 +5,10 @@ class User < ApplicationRecord
          :recoverable, :rememberable, :trackable, :validatable
 
   has_many :jobs
+
+  def is_owner?(job)
+    if job.user_id == self.id
+      return true
+    end
+  end
 end

--- a/app/views/devise/confirmations/new.html.haml
+++ b/app/views/devise/confirmations/new.html.haml
@@ -1,7 +1,8 @@
 - content_for :title do
   = "#{t('app.name')} | Resend Confirmation Instructions"
 %h1.page--title Resend confirmation instructions
-%p.page--legend Fill this form to resend confirmation
+.page--legend-buttons
+  %p.page--legend Fill this form to resend confirmation
 .main--content
   = form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post }) do |f|
     = devise_error_messages!

--- a/app/views/devise/passwords/edit.html.haml
+++ b/app/views/devise/passwords/edit.html.haml
@@ -2,7 +2,8 @@
   = "#{t('app.name')} | Change Your Password"
 
 %h2 Change your password
-%p.page--legend Stay secure, keep password strong!
+.page--legend-buttons
+  %p.page--legend Stay secure, keep password strong!
 .main--content 
   = form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f|
     = devise_error_messages!

--- a/app/views/devise/passwords/new.html.haml
+++ b/app/views/devise/passwords/new.html.haml
@@ -2,7 +2,8 @@
   = "#{t('app.name')} | Forgot Your Password?"
 
 %h1.page--title Forgot your password?
-%p.page--legend Don't forget set a strong password
+.page--legend-buttons
+  %p.page--legend Don't forget set a strong password
 .main--content
   = form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f|
     = devise_error_messages!

--- a/app/views/devise/registrations/edit.html.haml
+++ b/app/views/devise/registrations/edit.html.haml
@@ -2,7 +2,8 @@
   = "#{t('app.name')} | Edit My Account"
 
 %h1.page--title Edit #{resource_name.to_s.humanize}
-%p.page--legend Update your account details
+.page--legend-buttons
+  %p.page--legend Update your account details
 .main--content
   = form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f|
     = devise_error_messages!

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -2,7 +2,8 @@
   = "#{t('app.name')} | Sign Up"
 
 %h1.page--title Sign up
-%p.page--legend Get ready to hire the best talent ever!
+.page--legend-buttons
+  %p.page--legend Get ready to hire the best talent ever!
 .main--content
   = form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f|
     = devise_error_messages!

--- a/app/views/devise/unlocks/new.html.haml
+++ b/app/views/devise/unlocks/new.html.haml
@@ -2,7 +2,8 @@
   = "#{t('app.name')} | Resend Unlock Instructions"
 
 %h1.page--title Resend unlock instructions
-%p.page--legend Be sure to enter the correct email
+.page--legend-buttons
+  %p.page--legend Be sure to enter the correct email
 
 .main--content
   = form_for(resource, as: resource_name, url: unlock_path(resource_name), html: { method: :post }) do |f|

--- a/app/views/jobs/_form.html.haml
+++ b/app/views/jobs/_form.html.haml
@@ -43,8 +43,8 @@
   .field
     = form.label :phone
     = form.text_field :phone
-  -# .field
-  -#   = form.label :archived
-  -#   = form.check_box :archived
+  .field
+    = form.label :archived
+    = form.check_box :archived
   .actions
     = form.submit

--- a/app/views/jobs/_jobs-list.html.haml
+++ b/app/views/jobs/_jobs-list.html.haml
@@ -4,6 +4,9 @@
             = link_to job.role + " at " + job.company, job, :class => "job--list__item-link"
             .job--list__action-group
                 - if user_signed_in? && job.user_id == current_user.id
-                    -# = link_to '...', toggle_archive_path(job), :class => "job--list__archive-link", method: :patch
-                    = link_to 'Edit', edit_job_path(job), :class => "job--list__edit-link"
+                    - if job.is_archived?
+                        -# = link_to 'Unarchive', archive_path(job), :class => "job--list__action job--list__action-unarchive", method: :patch
+                    - else
+                        -# = link_to 'Archive', archive_path(job), :class => "job--list__action job--list__action-archive", method: :patch
+                    = link_to 'Edit', edit_job_path(job), :class => "job--list__action job--list__action-edit"
                 

--- a/app/views/jobs/_my-jobs-list.html.haml
+++ b/app/views/jobs/_my-jobs-list.html.haml
@@ -1,7 +1,14 @@
 %ul.job--list
     - @jobs.each do |job|
-        %li.job--list__item
-            = link_to job.role + " at " + job.company, job, :class => "job--list__item-link"
-            = link_to 'Edit', edit_job_path(job), :class => "job--list__edit-link"
-            
-            
+        - if job.is_archived?
+            %li.job--list__item.job--list__item-archived
+                = link_to job.role + " at " + job.company, job, :class => "job--list__item-link"
+                .job--list__action-group
+                    -# = link_to 'Unarchive', archive_job_path(job), :class => "job--list__action job--list__action-unarchive"
+                    = link_to 'Edit', edit_job_path(job), :class => "job--list__action job--list__action-edit"
+        - else      
+            %li.job--list__item
+                = link_to job.role + " at " + job.company, job, :class => "job--list__item-link"
+                .job--list__action-group
+                    -# = link_to 'Archive', archive_job_path(job), :class => "job--list__action job--list__action-archive"
+                    = link_to 'Edit', edit_job_path(job), :class => "job--list__action job--list__action-edit"

--- a/app/views/jobs/edit.html.haml
+++ b/app/views/jobs/edit.html.haml
@@ -2,7 +2,8 @@
   = "#{t('app.name')} | Edit Job - #{@job.role} at #{@job.company}"
 
 %h1.page--title Editing Job
-%p.page--legend= @job.role + " at " + @job.company
+.page--legend-buttons
+  %p.page--legend= @job.role + " at " + @job.company
 
 .main--content
   = render 'form', job: @job

--- a/app/views/jobs/index.html.haml
+++ b/app/views/jobs/index.html.haml
@@ -2,7 +2,8 @@
   = "#{t('app.name')} | All Jobs"
 
 %h1.page--title All Jobs
-%p.page--legend All the DevCongress Job Board listing here
+.page--legend-buttons
+  %p.page--legend All the DevCongress Job Board listing here
 
 .main--content
   = render 'jobs/jobs-list'

--- a/app/views/jobs/myjobs.html.haml
+++ b/app/views/jobs/myjobs.html.haml
@@ -2,10 +2,12 @@
   = "#{t('app.name')} | My Jobs"
 
 %h1.page--title All My Jobs
-%p.page--legend Jobs you have listed will appear here
+.page--legend-buttons
+  %p.page--legend Jobs you have listed are here. Archived jobs are hidden from public view, and have a cream background.
 .main--content
   - if @jobs.empty?
     %p You have no jobs listed yet. 🤔
+    -# %p Once a post has been created, you will not be able to delete it. Instead, you will be able to unhide it from public view. This is . 
     = link_to 'List your first Job', new_job_path
   - else
     = render 'jobs/my-jobs-list'

--- a/app/views/jobs/show.html.haml
+++ b/app/views/jobs/show.html.haml
@@ -2,7 +2,11 @@
   = "#{t('app.name')} | #{@job.role} at #{@job.company}"
 
 %h1.page--title= @job.role + " at " + @job.company
-%p.page--legend Listed by #{@job.poster_name} #{time_ago_in_words(@job.created_at)} ago
+.page--legend-buttons
+  %p.page--legend Listed by #{@job.poster_name} #{time_ago_in_words(@job.created_at)} ago
+  .share--buttons
+    = link_to('Tweet', tweetButtonText, :target => "_blank", :class => "share--button share--buttons__tweet", "data-hashtags" => "devcongressjobs", "data-related" => "DevCongress")
+    = link_to('Share', fbButtonText, :target => "_blank", :class => "share--button share--buttons__fb", "data-hashtags" => "devcongressjobs", "data-related" => "DevCongress")
 
 .main--content
   %h2.job--field__title Role

--- a/app/views/pages/about.html.haml
+++ b/app/views/pages/about.html.haml
@@ -2,7 +2,8 @@
   = "#{t('app.name')} | About"
   
 %h1.page--title About DevCongress Jobs
-%p.page--legend All you have wanted to know about this website
+.page--legend-buttons
+  %p.page--legend All you have wanted to know about this website
  
 .main--content
-  %p Find me in app/views/pages/about.html.erb
+  %p DevCongress Jobs has been created to help employers find tech talent across Africa. Have any more quesitons? Email us at jobs@devcongress.org

--- a/app/views/pages/help.html.haml
+++ b/app/views/pages/help.html.haml
@@ -2,7 +2,8 @@
   = "#{t('app.name')} | Help"
 
 %h1.page--title Help
-%p.page--legend Find help in times of need
+.page--legend-buttons
+  %p.page--legend Find help in times of need
 
 .main--content  
-  %p Find me in app/views/pages/help.html.erb
+  %p Any questions? Mail us at jobs@devcongress.org

--- a/app/views/pages/index.html.haml
+++ b/app/views/pages/index.html.haml
@@ -2,7 +2,8 @@
   = "#{t('app.name')} | Home"
 
 %h1.page--title.text--center DevCongress Jobs
-%p.page--legend Welcome to the DevCongress Job Board. Hire great people here.
+.page--legend-buttons
+  %p.page--legend Welcome to the DevCongress Job Board. Hire great people here.
 
 .main--content
   = render 'jobs/jobs-list'

--- a/app/views/pages/privacy.html.haml
+++ b/app/views/pages/privacy.html.haml
@@ -2,7 +2,8 @@
   = "#{t('app.name')} | Privacy"
 
 %h1.page--title Privacy
-%p.page--legend Errm, no personal information but still...
+.page--legend-buttons
+  %p.page--legend Errm, no personal information but still...
 
 .main--content
-  %p Find me in app/views/pages/privacy.html.erb
+  %p We don't keep any private information about you. We only store your email and the name you share when craeting a job post. Both of them are open to users ot the website. Beyond that, we keep no other information about you.

--- a/config/initializers/twitter.rb
+++ b/config/initializers/twitter.rb
@@ -1,0 +1,8 @@
+#!/usr/bin/env ruby
+
+# client = Twitter::REST::Client.new do |config|
+#   config.consumer_key        = ENV['TWITTER_CONSUMER_KEY']
+#   config.consumer_secret     = ENV['TWITTER_CONSUMER_SECRET']
+#   config.access_token        = ENV['TWITTER_ACCESS_TOKEN']
+#   config.access_token_secret = ENV['TWITTER_ACCESS_SECRET']
+# end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,8 +7,8 @@ Rails.application.routes.draw do
   resources :jobs
   root to: "pages#index"
 
-  get '/myjobs/',  to: 'jobs#myjobs', as: :user_jobs
-  patch '/toggle', to: 'jobs#toggle_archive', as: 'toggle_archive'
+  get '/myjobs',  to: 'jobs#myjobs', as: :user_jobs
+  patch '/archivable/:job', to: 'jobs#archivable', as: :archive_job
 
 
   devise_for :users, skip: [:sessions, :registrations, :passwords]


### PR DESCRIPTION
1. I changed the content in the other static pages; privacy, about and help pages with some minimal but relevant information
2. Disabled the twitter gem so i could work on it better later
3. Made some style changes to navbar to make border bottom color match link text color
4. Activated the archive checkbox in the job edit form
5. Users can now archive job posts
- 	Archived job posts will not show to anyone except the owner of the job post
- 	When they show to the owners, they have a different background to make them stand out from 
other active jobs
6. Made some page changes to the header area to allow for share buttons
-	Added tweet link which shares page link to Twitter
-	Added share link which shares page link to Facebook
7. Added some helper methods to check ownership for job posts
8. Tried adding a patch method to toggle archiving from the job list view, couldn't get that to work.
-	Related code for that exists but has been commented out