### PR TITLE
Add remote_ok option to job post

### DIFF
--- a/app/controllers/jobs_controller.rb
+++ b/app/controllers/jobs_controller.rb
@@ -1,8 +1,9 @@
 # require 'twitter'
 
 class JobsController < ApplicationController
-  before_action :set_job, only: [:show, :edit, :update, :destroy, :toggle_archive]
-  before_action :require_permission, only: [:edit, :destroy]
+  before_action :set_job,            only: [:show, :edit, :update, :destroy, :toggle_archive]
+  before_action :require_ownership,  only: [:edit, :destroy]
+  before_action :authenticate_user!, only: [:new, :create]
 
   def index
     @jobs = Job.where(archived: false).order('created_at DESC')
@@ -32,20 +33,11 @@ class JobsController < ApplicationController
   end
 
   def create
-    if current_user
-      @job = current_user.jobs.build(job_params)
-    end
-
-    respond_to do |format|
-      if @job.save
-        format.html { redirect_to @job, notice: 'Job was successfully created.' }
-        format.json { render :show, status: :created, location: @job }
-        # send tweet
-        # client.update("New Job posted on DevCongress jobs.")
-      else
-        format.html { render :new }
-        format.json { render json: @job.errors, status: :unprocessable_entity }
-      end
+    @job = current_user.jobs.build(job_params)
+    if @job.save
+      redirect_to @job, status: :created
+    else
+      render :new
     end
   end
 
@@ -73,16 +65,17 @@ class JobsController < ApplicationController
     end
   end
 
-  def require_permission
-    if current_user != @job.user
-      # redirect_to root_path
-      respond_to do |format|
-        format.html { redirect_to root_path, notice: 'You are not authorized to edit another users job post.' }
+  private
+
+    def require_ownership
+      if current_user != @job.user
+        # redirect_to root_path
+        respond_to do |format|
+          format.html { redirect_to root_path, notice: 'You are not authorized to edit another users job post.' }
+        end
       end
     end
-  end
 
-  private
     # Use callbacks to share common setup or constraints between actions.
     def set_job
       @job = Job.find(params[:id])
@@ -103,7 +96,8 @@ class JobsController < ApplicationController
       :poster_email,
       :phone,
       :user_id,
-      :archived)
+      :archived,
+      :remote_ok)
     end
 
     def raise_not_found

--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -16,6 +16,7 @@
 #  updated_at    :datetime         not null
 #  user_id       :integer
 #  archived      :boolean          default(FALSE)
+#  remote_ok     :boolean          default(TRUE), not null
 #
 
 class Job < ApplicationRecord

--- a/app/views/jobs/_form.html.erb
+++ b/app/views/jobs/_form.html.erb
@@ -20,6 +20,9 @@
     <span class="pure-form-message">What will be their title at the new role?</span>
   </div>
   <div class="field">
+    <%= form.check_box :remote_ok %> Remote OK
+  </div>
+  <div class="field">
     <%= form.label :duration %>
     <%= form.select(:duration, {"Full-time" => "Full-Time", "Contract" => "Contract", "Internship" => "Internship"}) %>
     <span class="pure-form-message">What is the duration for this project?</span>
@@ -51,18 +54,6 @@
   <div class="field">
     <%= form.label :contact_email %>
     <%= form.email_field :contact_email %>
-  </div>
-  <div class="field">
-    <%= form.label :poster_name %>
-    <%= form.text_field :poster_name %>
-  </div>
-  <div class="field">
-    <%= form.label :phone %>
-    <%= form.text_field :phone %>
-  </div>
-  <div class="field">
-    <%= form.label :archived %>
-    <%= form.check_box :archived %>
   </div>
   <div class="actions">
     <%= form.submit %>

--- a/app/views/jobs/show.html.erb
+++ b/app/views/jobs/show.html.erb
@@ -23,6 +23,10 @@
   <p class="job--field__content">
     <%= @job.salary %>
   </p>
+  <h2 class="job--field__title">Remote OK</h2>
+  <p class="job--field__content">
+    <%= @job.remote_ok ? "Yes" : "No" %>
+  </p>
   <h2 class="job--field__title">Requirements</h2>
   <%= simple_format h(@job.requirements), :class => "job--field__content" %>
   <h2 class="job--field__title">Qualification</h2>

--- a/db/migrate/20181012163952_add_remote_ok_to_jobs.rb
+++ b/db/migrate/20181012163952_add_remote_ok_to_jobs.rb
@@ -1,0 +1,5 @@
+class AddRemoteOkToJobs < ActiveRecord::Migration[5.2]
+  def change
+    add_column :jobs, :remote_ok, :boolean, null: false, default: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_10_11_121512) do
+ActiveRecord::Schema.define(version: 2018_10_12_163952) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -29,6 +29,7 @@ ActiveRecord::Schema.define(version: 2018_10_11_121512) do
     t.datetime "updated_at", null: false
     t.integer "user_id"
     t.boolean "archived", default: false
+    t.boolean "remote_ok", default: true, null: false
     t.index ["user_id"], name: "index_jobs_on_user_id"
   end
 

--- a/test/controllers/jobs_controller_test.rb
+++ b/test/controllers/jobs_controller_test.rb
@@ -1,9 +1,12 @@
 require 'test_helper'
 
 class JobsControllerTest < ActionDispatch::IntegrationTest
+  include Devise::Test::IntegrationHelpers
+
   setup do
     @available_jobs = create_list(:job, 3)
     @archived_job = create(:job, archived: true) # one archived job
+    @user = create(:user)
   end
 
   test "should get index" do
@@ -37,6 +40,24 @@ class JobsControllerTest < ActionDispatch::IntegrationTest
   test "should not find archived job" do
     assert_raise ActionController::RoutingError do
       get job_url(@archived_job)
+    end
+  end
+
+  test "should fail for unauthenticated user" do
+    job_params = attributes_for(:job)
+    puts job_params.inspect
+    post jobs_url, params: {job: job_params}
+    assert_redirected_to new_user_session_url
+  end
+
+  test "should create a new job post" do
+    sign_in @user
+
+    assert_difference('Job.count') do
+      job_params = attributes_for(:job)
+      post jobs_url, params: {job: job_params}
+
+      assert_response :created
     end
   end
 end

--- a/test/factories/jobs.rb
+++ b/test/factories/jobs.rb
@@ -1,3 +1,24 @@
+# == Schema Information
+#
+# Table name: jobs
+#
+#  id            :bigint(8)        not null, primary key
+#  role          :string
+#  duration      :string
+#  salary        :string
+#  requirements  :string
+#  qualification :string
+#  perks         :string
+#  company       :string
+#  contact_email :string
+#  phone         :string
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#  user_id       :integer
+#  archived      :boolean          default(FALSE)
+#  remote_ok     :boolean          default(TRUE), not null
+#
+
 FactoryBot.define do
   sequence (:company_email) { |n| "company#{n}@example.org" }
 
@@ -5,7 +26,7 @@ FactoryBot.define do
     user
     company       { Faker::Company.name }
     qualification { Faker::Job.key_skill }
-    requirements  { Faker::Lorem.paragraphs(2) }
+    requirements  { Faker::Lorem.paragraph(2) }
     role          { Faker::Job.title }
     contact_email { generate(:company_email) }
     salary        { "USD #{rand(1..2)} - #{rand(3..5)}" }

--- a/test/factories/users.rb
+++ b/test/factories/users.rb
@@ -1,3 +1,22 @@
+# == Schema Information
+#
+# Table name: users
+#
+#  id                     :bigint(8)        not null, primary key
+#  email                  :string           default(""), not null
+#  encrypted_password     :string           default(""), not null
+#  reset_password_token   :string
+#  reset_password_sent_at :datetime
+#  remember_created_at    :datetime
+#  sign_in_count          :integer          default(0), not null
+#  current_sign_in_at     :datetime
+#  last_sign_in_at        :datetime
+#  current_sign_in_ip     :string
+#  last_sign_in_ip        :string
+#  created_at             :datetime         not null
+#  updated_at             :datetime         not null
+#
+
 FactoryBot.define do
   sequence(:user_email) { |n| "user#{n}@example.org" }
 

--- a/test/models/job_test.rb
+++ b/test/models/job_test.rb
@@ -16,6 +16,7 @@
 #  updated_at    :datetime         not null
 #  user_id       :integer
 #  archived      :boolean          default(FALSE)
+#  remote_ok     :boolean          default(TRUE), not null
 #
 
 require 'test_helper'


### PR DESCRIPTION
Recruiters can now say if their position is open to remote applicants.