### PR TITLE
Make jobs active within a window

### DIFF
--- a/app/controllers/jobs_controller.rb
+++ b/app/controllers/jobs_controller.rb
@@ -6,7 +6,7 @@ class JobsController < ApplicationController
   before_action :authenticate_user!, only: [:new, :create]
 
   def index
-    @jobs = Job.where(archived: false).order("created_at DESC")
+    @jobs = Job.all_active
   end
 
   def show

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,6 +1,6 @@
 class PagesController < ApplicationController
   def index
-    @jobs = Job.where(:archived => false).order('created_at DESC')    
+    @jobs = Job.all_active
   end
 
   def help

--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -39,19 +39,19 @@ class Job < ApplicationRecord
   # `Job.active` is a version of `all` that returns
   # jobs that haven't been archived and are still within
   # the validity period since they were posted.
-  def self.active
+  def self.all_active
     Job.find_by_sql <<-SQL
-    SELECT *
-    FROM jobs
-    WHERE NOT archived
-          AND tsrange(
-            created_at,
-            created_at + INTERVAL '#{self.validity_period}' DAY, '[]'
-          ) @> now()::timestamp
+      SELECT *
+      FROM jobs
+      WHERE NOT archived
+            AND tsrange(
+              created_at,
+              created_at + INTERVAL '#{self.validity_period}' DAY, '[]'
+            ) @> now()::timestamp
     SQL
   end
 
   def self.validity_period
-    ENV['JOB_VALIDITY_PERIOD'].to_i
+    (ENV['JOB_VALIDITY_PERIOD'] || 30).to_i.abs
   end
 end

--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -35,4 +35,23 @@ class Job < ApplicationRecord
   def title
     "#{role} at #{company.name}"
   end
+
+  # `Job.active` is a version of `all` that returns
+  # jobs that haven't been archived and are still within
+  # the validity period since they were posted.
+  def self.active
+    Job.find_by_sql <<-SQL
+    SELECT *
+    FROM jobs
+    WHERE NOT archived
+          AND tsrange(
+            created_at,
+            created_at + INTERVAL '#{self.validity_period}' DAY, '[]'
+          ) @> now()::timestamp
+    SQL
+  end
+
+  def self.validity_period
+    ENV['JOB_VALIDITY_PERIOD'].to_i
+  end
 end

--- a/test/models/job_test.rb
+++ b/test/models/job_test.rb
@@ -23,7 +23,7 @@ require 'test_helper'
 class JobTest < ActiveSupport::TestCase
 
   setup do
-    @subject = FactoryBot.build(:job)
+    @subject = FactoryBot.create(:job, created_at: DateTime.now - 1.day)
   end
 
   test "associations" do
@@ -36,5 +36,25 @@ class JobTest < ActiveSupport::TestCase
     must validate_presence_of :requirements
     must validate_presence_of :qualification
     must validate_presence_of :role
+  end
+
+  test "all_active" do
+    # Uses the default validity period. See the
+    # self.validity_period in model for what the
+    # current value is.
+    past_date   = DateTime.now - (Job.validity_period + 1).days
+    future_date = DateTime.now + (Job.validity_period + 1).days
+
+    # These jobs are not matched since they fall
+    # outside of the range of active job post. One of
+    # them is archived.
+    FactoryBot.create(:job, archived: true)
+    FactoryBot.create(:job, created_at: future_date)
+    FactoryBot.create(:job, created_at: past_date)
+
+    active_job_posts = Job.all_active
+
+    assert_equal 1, active_job_posts.length
+    assert_equal @subject.id, active_job_posts.first.id
   end
 end


### PR DESCRIPTION
By default jobs are valid 30 days after they are created. This could change when we have draft mode for job creation. The validity period is controlled by the environment variable `JOB_VALIDITY_PERIOD`.