### PR TITLE
Apply link

### DIFF
--- a/app/controllers/jobs_controller.rb
+++ b/app/controllers/jobs_controller.rb
@@ -101,7 +101,8 @@ class JobsController < ApplicationController
         :archived,
         :remote_ok,
         :city,
-        :country)
+        :country,
+        :apply_link)
     end
 
     def raise_not_found

--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -16,6 +16,7 @@
 #  company_id    :bigint(8)        not null
 #  city          :string           default(""), not null
 #  country       :string           default(""), not null
+#  apply_link    :text             default(""), not null
 #
 
 class Job < ApplicationRecord

--- a/app/views/jobs/_form.html.erb
+++ b/app/views/jobs/_form.html.erb
@@ -63,6 +63,10 @@
     <%= form.label :country %>
     <%= form.text_field :country %>
   </div>
+  <div class="field">
+    <%= form.label :apply_link, "Link to Apply" %>
+    <%= form.url_field :apply_link %>
+  </div>
   <div class="actions">
     <%= form.submit %>
   </div>

--- a/db/migrate/20181113012450_add_apply_link_to_jobs.rb
+++ b/db/migrate/20181113012450_add_apply_link_to_jobs.rb
@@ -1,0 +1,5 @@
+class AddApplyLinkToJobs < ActiveRecord::Migration[5.2]
+  def change
+    add_column :jobs, :apply_link, :text, null: false, default: ''
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_11_06_011104) do
+ActiveRecord::Schema.define(version: 2018_11_13_012450) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -62,6 +62,7 @@ ActiveRecord::Schema.define(version: 2018_11_06_011104) do
     t.bigint "company_id", null: false
     t.string "city", default: "", null: false
     t.string "country", default: "", null: false
+    t.text "apply_link", default: "", null: false
     t.index ["company_id"], name: "index_jobs_on_company_id"
   end
 

--- a/test/factories/jobs.rb
+++ b/test/factories/jobs.rb
@@ -16,6 +16,7 @@
 #  company_id    :bigint(8)        not null
 #  city          :string           default(""), not null
 #  country       :string           default(""), not null
+#  apply_link    :text             default(""), not null
 #
 
 FactoryBot.define do
@@ -33,5 +34,6 @@ FactoryBot.define do
     remote_ok     { true }
     city          { Faker::Address.city }
     country       { Faker::Address.country }
+    apply_link    { Faker::Internet.url }
   end
 end

--- a/test/models/job_test.rb
+++ b/test/models/job_test.rb
@@ -16,6 +16,7 @@
 #  company_id    :bigint(8)        not null
 #  city          :string           default(""), not null
 #  country       :string           default(""), not null
+#  apply_link    :text             default(""), not null
 #
 
 require 'test_helper'


### PR DESCRIPTION
Allow recruiters to set a link that applicants should use to apply. Some recruiters use an end-to-end tool to management recruitment (we did this at MEST).