### PR TITLE
Add functionality to mark job as filled or vacant

### DIFF
--- a/app/controllers/jobs_controller.rb
+++ b/app/controllers/jobs_controller.rb
@@ -1,39 +1,21 @@
 # require "twitter"
 
 class JobsController < ApplicationController
-  before_action :set_job,            only: [:show, :edit, :update, :destroy, :toggle_archive]
+  before_action :set_job,            except: [:new, :index, :myjobs]
+  before_action :authenticate_user!, except: [:index, :show]
   before_action :require_ownership,  only: [:edit, :destroy]
-  before_action :authenticate_user!, only: [:new, :create]
 
   def index
     @jobs = Job.all_active
   end
 
-  def show
-    raise_not_found if @job.archived?
-  end
-
-  def myjobs
-    if user_signed_in?
-      @jobs = current_user.jobs.order("created_at DESC")
-    else
-      redirect_to new_user_session_path, notice: "Sign in to see jobs you have posted"
-    end
-  end
-
   def new
-    if user_signed_in?
-      @companies = current_user.companies
-      unless @companies.count > 0
-        redirect_to new_company_path, notice: "Register company first"
-      end
-      @job = Job.new
-    else
-      redirect_to new_user_session_path, notice: "Sign in to create a job post"
+    @companies = current_user.companies
+    if @companies.empty?
+      redirect_to new_company_path, notice: "Register company first"
+      return
     end
-  end
-
-  def edit
+    @job = Job.new
   end
 
   def create
@@ -48,18 +30,33 @@ class JobsController < ApplicationController
     end
   end
 
-  # PATCH/PUT /jobs/1
-  # PATCH/PUT /jobs/1.json
+  def show
+    raise_not_found if @job.archived?
+  end
+
+  def edit
+  end
+
   def update
-    respond_to do |format|
-      if @job.update(job_params)
-        format.html { redirect_to @job, notice: "Job was successfully updated." }
-        format.json { render :show, status: :ok, location: @job }
-      else
-        format.html { render :edit }
-        format.json { render json: @job.errors, status: :unprocessable_entity }
-      end
+    if @job.update(edit_job_params)
+      redirect_to @job, notice: "Job has been updated."
+    else
+      render :edit
     end
+  end
+
+  def myjobs
+    @jobs = current_user.jobs.order("created_at DESC")
+  end
+
+  def filled
+    @job.update_attribute(:filled_at, DateTime.now)
+    redirect_to @job
+  end
+
+  def vacant
+    @job.update_attribute(:filled_at, nil)
+    redirect_to @job
   end
 
   # DELETE /jobs/1
@@ -75,7 +72,7 @@ class JobsController < ApplicationController
   private
 
     def require_ownership
-      unless current_user == @job.user
+      unless current_user.companies.includes(@job.company)
         redirect_to root_path, notice: "You are not authorized to edit this job post."
       end
     end
@@ -98,7 +95,20 @@ class JobsController < ApplicationController
         :qualification,
         :perks,
         :company_id,
-        :archived,
+        :remote_ok,
+        :city,
+        :country,
+        :apply_link)
+    end
+
+    def edit_job_params
+      params.require(:job).permit(
+        :role,
+        :duration,
+        :salary,
+        :requirements,
+        :qualification,
+        :perks,
         :remote_ok,
         :city,
         :country,

--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -17,6 +17,7 @@
 #  city          :string           default(""), not null
 #  country       :string           default(""), not null
 #  apply_link    :text             default(""), not null
+#  filled_at     :datetime
 #
 
 class Job < ApplicationRecord
@@ -30,7 +31,7 @@ class Job < ApplicationRecord
   validates :role,          presence: true
 
   def to_param
-    "#{id}-#{role}-#{company}".parameterize
+    "#{id}-#{role}-at-#{company.name}".parameterize
   end
 
   def title
@@ -45,6 +46,7 @@ class Job < ApplicationRecord
       SELECT *
       FROM jobs
       WHERE NOT archived
+            AND filled_at IS NULL
             AND tsrange(
               created_at,
               created_at + INTERVAL '#{self.validity_period}' DAY, '[]'

--- a/app/views/jobs/edit.html.erb
+++ b/app/views/jobs/edit.html.erb
@@ -8,8 +8,72 @@
   </p>
 </div>
 <div class="main--content">
-  <%= render 'form', job: @job %>
-  <%= link_to 'Show', @job %>
-  |
-  <%= link_to 'Back', jobs_path %>
+<%= form_with(model: @job, local: true, :class => "pure-form pure-form-stacked") do |form| %>
+  <% if @job.errors.any? %>
+    <div class="error_explanation">
+      <h2>
+        <%= pluralize(job.errors.count, "error") %>
+        prohibited this job from being saved:
+      </h2>
+      <ul>
+        <% @job.errors.full_messages.each do |message| %>
+          <li>
+            <%= message %>
+          </li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+  <div class="field">
+    <%= form.label :role %>
+    <%= form.text_field :role %>
+    <span class="pure-form-message">What will be their title at the new role?</span>
+  </div>
+  <div class="field">
+    <%= form.check_box :remote_ok %> Remote OK
+  </div>
+  <div class="field">
+    <%= form.label :duration %>
+    <%= form.select(:duration, {"Full-time" => "Full-Time", "Contract" => "Contract", "Internship" => "Internship"}) %>
+    <span class="pure-form-message">What is the duration for this project?</span>
+  </div>
+  <div class="field">
+    <%= form.label :salary %>
+    <%= form.select(:salary, {"Up to USD 500" => "Up to USD 500", "USD 500 - 1k" => "USD 500 - 1k", "USD 1k - 2k" => "USD 1k - 2k", "USD 2k - 3k" => "USD 2k - 3k", "USD 3k+" => "USD 3k+"})  %>
+    <span class="pure-form-message">Please note: there's a correlation between experience/expertise and compensation. Therefore, it's important to provide a figure to attract the right pool of candidates.</span>
+  </div>
+  <div class="field">
+    <%= form.label :requirements %>
+    <%= form.text_area :requirements %>
+    <span class="pure-form-message">What are the 1 to 3 main things you need your future developer to help with? Please feel free to keep this as simple as possible and use every day language. Please be as specific as possible. For example: "I need the developer to help us build a new iPhone app"</span>
+  </div>
+  <div class="field">
+    <%= form.label :qualification %>
+    <%= form.text_area :qualification %>
+    <span class="pure-form-message">This could be anything from "I require the developer to be fluent in French" to something as technical as "I require the developer to have an expert-level familiarity with PHP"</span>
+  </div>
+  <div class="field">
+    <%= form.label :perks %>
+    <%= form.text_area :perks %>
+    <span class="pure-form-message">Please remember that the best developers are motivated by a mission. Please *sell* the project succinctly.</span>
+  </div>
+  <div class="field">
+    <%= form.label :city %>
+    <%= form.text_field :city %>
+  </div>
+  <div class="field">
+    <%= form.label :country %>
+    <%= form.text_field :country %>
+  </div>
+  <div class="field">
+    <%= form.label :apply_link, "Link to Apply" %>
+    <%= form.url_field :apply_link %>
+  </div>
+  <div class="actions">
+    <%= form.submit %>
+  </div>
+<% end %>
+<%= link_to 'Show', @job %>
+|
+<%= link_to 'Back', jobs_path %>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,8 +6,13 @@ Rails.application.routes.draw do
   get '/about' => 'pages#about'
   get '/privacy' => 'pages#privacy'
   
-  resources :jobs
   resources :companies
+  resources :jobs do
+    member do
+      post "filled"
+      post "vacant"
+    end
+  end
 
   get '/myjobs',  to: 'jobs#myjobs', as: :user_jobs
 

--- a/db/migrate/20181202105418_add_filled_at_to_jobs.rb
+++ b/db/migrate/20181202105418_add_filled_at_to_jobs.rb
@@ -1,0 +1,5 @@
+class AddFilledAtToJobs < ActiveRecord::Migration[5.2]
+  def change
+    add_column :jobs, :filled_at, :timestamp
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_11_13_012450) do
+ActiveRecord::Schema.define(version: 2018_12_02_105418) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -63,6 +63,7 @@ ActiveRecord::Schema.define(version: 2018_11_13_012450) do
     t.string "city", default: "", null: false
     t.string "country", default: "", null: false
     t.text "apply_link", default: "", null: false
+    t.datetime "filled_at"
     t.index ["company_id"], name: "index_jobs_on_company_id"
   end
 

--- a/test/controllers/jobs_controller_test.rb
+++ b/test/controllers/jobs_controller_test.rb
@@ -72,4 +72,43 @@ class JobsControllerTest < ActionDispatch::IntegrationTest
       post jobs_url, params: {job: job_params}
     end
   end
+
+  test "should be able to edit a job post" do
+    job = FactoryBot.create(:job, company: @company)
+    job_params = attributes_for(:job, company: FactoryBot.create(:company))
+
+    sign_in @user
+    put job_url(job), params: {job: job_params}
+
+    job.reload
+    assert_redirected_to job
+    assert_equal job.company, @company # Job's company cannot be changed.
+    assert_equal job.role, job_params[:role]
+
+    updated_attrs = job.attributes.except("id", "created_at", "updated_at", "company_id")
+    updated_attrs.each { |k, v| assert_equal v, job_params[k.to_sym] if v }
+  end
+
+  test "should be able to mark a job post (position) as filled" do
+    job = FactoryBot.create(:job, company: @company)
+
+    sign_in @user
+    post filled_job_url(job)
+
+    job.reload
+    assert_redirected_to job
+    refute_nil job.filled_at
+    assert job.filled_at < DateTime.now
+  end
+
+  test "should be able to mark a filled job as vacant" do
+    job = FactoryBot.create(:job, company: @company, filled_at: DateTime.now)
+
+    sign_in @user
+    post vacant_job_url(job)
+
+    job.reload
+    assert_redirected_to job
+    assert_nil job.filled_at
+  end
 end

--- a/test/factories/jobs.rb
+++ b/test/factories/jobs.rb
@@ -17,6 +17,7 @@
 #  city          :string           default(""), not null
 #  country       :string           default(""), not null
 #  apply_link    :text             default(""), not null
+#  filled_at     :datetime
 #
 
 FactoryBot.define do

--- a/test/models/job_test.rb
+++ b/test/models/job_test.rb
@@ -17,6 +17,7 @@
 #  city          :string           default(""), not null
 #  country       :string           default(""), not null
 #  apply_link    :text             default(""), not null
+#  filled_at     :datetime
 #
 
 require 'test_helper'
@@ -24,7 +25,7 @@ require 'test_helper'
 class JobTest < ActiveSupport::TestCase
 
   setup do
-    @subject = FactoryBot.create(:job, created_at: DateTime.now - 1.day)
+    @subject = FactoryBot.create(:job, created_at: 1.day.ago)
   end
 
   test "associations" do
@@ -48,10 +49,11 @@ class JobTest < ActiveSupport::TestCase
 
     # These jobs are not matched since they fall
     # outside of the range of active job post. One of
-    # them is archived.
+    # them is archived and another is already filled.
     FactoryBot.create(:job, archived: true)
     FactoryBot.create(:job, created_at: future_date)
     FactoryBot.create(:job, created_at: past_date)
+    FactoryBot.create(:job, created_at: 1.day.ago, filled_at: past_date)
 
     active_job_posts = Job.all_active
 


### PR DESCRIPTION
See [Trello card](https://trello.com/c/ZqRPFp1O/32-recruiter-should-be-able-to-change-the-status-of-their-job-posts-it-would-be-nice-to-know-if-theyve-filled-it-or-are-no-longer-h) for more details.