### PR TITLE
Send confirmation email to job post creator

### DIFF
--- a/app/controllers/jobs_controller.rb
+++ b/app/controllers/jobs_controller.rb
@@ -42,6 +42,7 @@ class JobsController < ApplicationController
 
     @job = company.jobs.build(job_params)
     if @job.save
+      JobsMailer.with(job: @job).published.deliver_later
       redirect_to @job, status: :created
     else
       render :new, status: :bad_request

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,4 +1,6 @@
 class ApplicationMailer < ActionMailer::Base
-  default from: 'jobs@devcongress.org'
+  default from: 'jobs@devcongress.org',
+          reply_to: 'jobs@devcongress.org'
+
   layout 'mailer'
 end

--- a/app/mailers/jobs_mailer.rb
+++ b/app/mailers/jobs_mailer.rb
@@ -1,0 +1,18 @@
+class JobsMailer < ApplicationMailer
+
+  # Subject can be set in your I18n file at config/locales/en.yml
+  # with the following lookup:
+  #
+  #   en.jobs_mailer.published.subject
+  #
+  def published
+    @job = params[:job]
+    @company = @job.company
+    @company_people = @company.users
+
+    subject = "New job published: #{@job.role} @ #{@company.name}"
+    to = @company_people.collect { |u| u.email }
+
+    mail(to: to, subject: subject)
+  end
+end

--- a/app/models/client.rb
+++ b/app/models/client.rb
@@ -16,5 +16,5 @@ class Client < ApplicationRecord
 
   # Validations
   validates :company, presence: true
-  validates :user,    presence: true
+  validates :user,   presence: true
 end

--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -21,6 +21,8 @@
 class Company < ApplicationRecord
   # Associations
   has_many :jobs
+  has_many :clients
+  has_many :users, through: :clients
 
   # Validations
   validates :name,            presence: true

--- a/app/views/jobs_mailer/published.html.erb
+++ b/app/views/jobs_mailer/published.html.erb
@@ -1,0 +1,13 @@
+<p>
+  A new job has been posted on <%= link_to "The Jobs Board", root_url %>
+  for your company. Please find the details below:
+</p>
+<!--
+  TO BE PROPERLY DONE.
+
+  The contents in this email only highlights what's the important
+  information to include. It currently has no design.
+-->
+<p>
+  Here's a link to the job post: <%= link_to @job.title, job_url(@job) %>.
+</p>

--- a/app/views/jobs_mailer/published.text.erb
+++ b/app/views/jobs_mailer/published.text.erb
@@ -1,0 +1,3 @@
+Jobs#published
+
+<%= @greeting %>, find me in app/views/jobs_mailer/published.text.erb

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -98,12 +98,12 @@ Rails.application.configure do
   config.action_mailer.default_url_options = { :host => 'jobs.devcongress.org' }
   
   ActionMailer::Base.smtp_settings = {
-    :address        => "smtp.sendgrid.net",
-    :port           => "25",
-    :authentication => :plain,
-    :user_name      => ENV['SENDGRID_USERNAME'],
-    :password       => ENV['SENDGRID_PASSWORD'],
-    :domain         => ENV['SENDGRID_DOMAIN']
+           address: "smtp.sendgrid.net",
+              port: "25",
+    authentication: :plain,
+         user_name: ENV['SENDGRID_USERNAME'],
+          password: ENV['SENDGRID_PASSWORD'],
+            domain: ENV['SENDGRID_DOMAIN']
   }
 
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -43,4 +43,7 @@ Rails.application.configure do
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
+
+
+  config.action_mailer.default_url_options = { host: 'localhost', port: 3000 }
 end

--- a/test/controllers/jobs_controller_test.rb
+++ b/test/controllers/jobs_controller_test.rb
@@ -55,11 +55,13 @@ class JobsControllerTest < ActionDispatch::IntegrationTest
   test "should create a new job post for user's client" do
     sign_in @user
 
-    assert_difference('Job.count') do
-      job_params = attributes_for(:job, company_id: @company.id)
-      post jobs_url, params: {job: job_params}
+    assert_enqueued_jobs @company.users.count do
+      assert_difference('Job.count') do
+        job_params = attributes_for(:job, company_id: @company.id)
+        post jobs_url, params: {job: job_params}
 
-      assert_response :created
+        assert_response :created
+      end
     end
   end
 

--- a/test/mailers/jobs_mailer_test.rb
+++ b/test/mailers/jobs_mailer_test.rb
@@ -1,0 +1,25 @@
+require 'test_helper'
+
+class JobsMailerTest < ActionMailer::TestCase
+  include Rails.application.routes.url_helpers
+
+  def default_url_options
+    Rails.application.config.action_mailer.default_url_options
+  end
+
+  test "published" do
+    client = FactoryBot.create(:client)
+    job    = FactoryBot.create(:job, company: client.company)
+    mail   = JobsMailer.with(job: job).published
+
+    assert_equal "New job published: #{job.role} @ #{job.company.name}", mail.subject
+    assert_equal [client.user.email], mail.to
+    assert_equal ["jobs@devcongress.org"], mail.from
+    assert_equal ["jobs@devcongress.org"], mail.reply_to
+
+    mail_body = mail.body.encoded
+    assert_match job.role,      mail_body
+    assert_match root_url,      mail_body
+    assert_match job_url(job),  mail_body
+  end
+end

--- a/test/mailers/previews/jobs_mailer_preview.rb
+++ b/test/mailers/previews/jobs_mailer_preview.rb
@@ -1,0 +1,9 @@
+# Preview all emails at http://localhost:3000/rails/mailers/jobs_mailer
+class JobsMailerPreview < ActionMailer::Preview
+
+  # Preview this email at http://localhost:3000/rails/mailers/jobs_mailer/published
+  def published
+    JobsMailer.published
+  end
+
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -5,6 +5,7 @@ require 'rails/test_help'
 class ActiveSupport::TestCase
   # Add more helper methods to be used by all tests here...
   include FactoryBot::Syntax::Methods
+  include ActiveJob::TestHelper
 
   Shoulda::Matchers.configure do |config|
     config.integrate do |with|


### PR DESCRIPTION
When someone posts a job, we should send them a confirmation email which also contains a link to the published post. This PR introduces this functionality.

See [Trello card](https://trello.com/c/0QsvbVnR/7-send-an-email-on-new-job) for more information.