### PR TITLE
Add search

### DIFF
--- a/app/controllers/jobs_controller.rb
+++ b/app/controllers/jobs_controller.rb
@@ -2,7 +2,7 @@
 
 class JobsController < ApplicationController
   before_action :set_job,            except: [:new, :index]
-  before_action :authenticate_user!, except: [:index, :show]
+  before_action :authenticate_user!, except: [:index, :show, :search]
   before_action :require_ownership,  only: [:edit, :destroy]
 
   def index
@@ -54,6 +54,14 @@ class JobsController < ApplicationController
   def vacant
     @job.update_attribute(:filled_at, nil)
     redirect_to @job
+  end
+
+  def search
+    @matches = Job.search(params[:q])
+    respond_to do |format|
+      format.html
+      format.json
+    end
   end
 
   # DELETE /jobs/1

--- a/app/views/jobs/search.html.erb
+++ b/app/views/jobs/search.html.erb
@@ -1,0 +1,20 @@
+<% if @matches.empty? %>
+<% else %>
+  <h3><%= pluralize(@matches.length, 'match') %> were found:</h3>
+  <ul>
+    <% @matches.each do |match| %>
+      <li>
+        <h4><%= link_to match.title, job_url(match) %></h4>
+        <p>
+        <!--
+          TODO: Right now we display the requirements of the job
+          but we should replace this with the part of the job post
+          that matched the user's query. And if possible highlight
+          the matched words or phrases.
+        -->
+          <%= match.requirements %>
+        </p>
+      </li>
+    <% end %>
+  </ul>
+<% end %>

--- a/app/views/jobs/search.json.jbuilder
+++ b/app/views/jobs/search.json.jbuilder
@@ -1,0 +1,28 @@
+json.array! @matches do |match|
+  json.(
+    match,
+    :created_at,
+    :role,
+    :duration,
+    :salary,
+    :requirements,
+    :qualification,
+    :perks,
+    :remote_ok,
+    :city,
+    :country,
+    :apply_link)
+  json.url job_url(match)
+
+  json.company(
+    match.company,
+    :name,
+    :industry,
+    :logo,
+    :website,
+    :description,
+    :city,
+    :state_or_region,
+    :post_code,
+    :country)
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,10 @@ Rails.application.routes.draw do
   
   resources :companies
   resources :jobs do
+    collection do
+      get 'search'
+    end
+
     member do
       post "filled"
       post "vacant"

--- a/test/controllers/jobs_controller_test.rb
+++ b/test/controllers/jobs_controller_test.rb
@@ -113,4 +113,18 @@ class JobsControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to job
     assert_nil job.filled_at
   end
+
+  test "search" do
+    first = FactoryBot.create(:job, role: "Senior Ruby on Rails Developer")
+    second = FactoryBot.create(:job, role: "Senior JavaScript Developer")
+    FactoryBot.create(:job) # not found
+
+    get search_jobs_url(q: "senior developer")
+
+    assert_match /2 matches were found/i, @response.body
+    assert_match first.role, @response.body
+    assert_match first.requirements, @response.body
+    assert_match second.role, @response.body
+    assert_match second.requirements, @response.body
+  end
 end

--- a/test/factories/jobs.rb
+++ b/test/factories/jobs.rb
@@ -36,5 +36,6 @@ FactoryBot.define do
     city          { Faker::Address.city }
     country       { Faker::Address.country }
     apply_link    { Faker::Internet.url }
+    created_at    { 1.day.ago }
   end
 end


### PR DESCRIPTION
It's not a sophisticated search functionality but it can find you all the Rails jobs posted on the jobs board so who cares? It also includes a JSON endpoint (not tested, yet) but trust me, it works :joy: 

This means that we can now add a search bar to the homepage (or toolbar so that it's accessible from everywhere), and @oddoye-david has an endpoint for his Slackbot command.