### PR TITLE
Jobs Order, Mail display name change

### DIFF
--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,5 +1,5 @@
 class ApplicationMailer < ActionMailer::Base
-  default from: 'jobs@devcongress.org',
+  default from: 'DevCongress Jobs',
           reply_to: 'jobs@devcongress.org'
 
   layout 'mailer'

--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -51,6 +51,7 @@ class Job < ApplicationRecord
               created_at,
               created_at + INTERVAL '#{self.validity_period}' DAY, '[]'
             ) @> now()::timestamp
+            ORDER BY created_at DESC
     SQL
   end
 
@@ -69,6 +70,7 @@ SELECT *
         created_at + INTERVAL '#{self.validity_period}' DAY, '[]'
        ) @> now()::timestamp
        AND plainto_tsquery(?) @@ full_text_search
+       ORDER BY created_at DESC
     SQL
   end
 end


### PR DESCRIPTION
Jobs are now displayed in descending order, with newer jobs at the top.
Also changed the from attribute to DevCongress Jobs for mailer.