### PR TITLE
enhancement:reduced docker build step

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,7 @@ RUN apt-get update
 # libpq-dev is required for the pg gem
 RUN apt-get install -y libpq-dev postgresql-client-10
 
-# Make app dir
-RUN mkdir /app
+# Set working directory for project
 WORKDIR /app
 
 # Import Gemfile

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This is the code which runs the DevCongress Jobs website, which lives at [jobs.d
 
 ### Requirements
 
-Install Docker and Docker Compose (Docker Compose comes with Docker on Windows and MacOS)
+[Install Docker and Docker Compose](https://docs.docker.com/v17.09/engine/installation/#supported-platforms) (Docker Compose comes with Docker on Windows and MacOS)
 
 ### Run Project
 


### PR DESCRIPTION
By default, `WORKDIR` creates the folder if it doesn't exist, as such, we don't exactly need to create the folder ourself anymore.