### PR TITLE
Port binding removed for postgres service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
     networks:
       - jobs
     ports:
-      - "5433:5432"
+      - "5432"
 
   web:
     build: .


### PR DESCRIPTION
Port supplied for binding to host computer removed. Binding ports led to conflict from the client computer due to ports already in use, thus left unmapped for random port binding.